### PR TITLE
Fix button action type "command" with arguments

### DIFF
--- a/src/workspaces/buttons.ts
+++ b/src/workspaces/buttons.ts
@@ -191,7 +191,7 @@ export async function reloadButtons() {
                                 const CMD_ID = ego_helpers.toStringSafe(CMD_ACTION.command);
                                 const CMD_ARGS: any[] =
                                     _.isNil(CMD_ACTION.arguments) ? []
-                                                                  : ego_helpers.asArray(CMD_ACTION, false);
+                                                                  : ego_helpers.asArray(CMD_ACTION.arguments, false);
 
                                 await Promise.resolve(
                                     vscode.commands.executeCommand


### PR DESCRIPTION
Currently, even though it seems like the following should work:
```json
{
  "text": "my button",
  "action": {
    "type": "command",
    "command": "workbench.action.tasks.runTask",
    "arguments": ["my task label"]
}
```

It doesn't, because of the typo which this patch fixes.